### PR TITLE
Add configuration for readthedocs.org

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,11 +19,4 @@ sphinx:
 # requirements and package requirements, it seems.
 python:
   install:
-    # - method: pip
-    #   path: .
-    #   extra_requirements:
-    #     - docs
-    - method: pip
-      path: furo
-    - method: pip
-      path: myst-parser
+    - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,6 +24,6 @@ python:
     #   extra_requirements:
     #     - docs
     - method: pip
-      package: furo
+      path: furo
     - method: pip
-      package: myst-parser
+      path: myst-parser

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,7 +19,11 @@ sphinx:
 # requirements and package requirements, it seems.
 python:
   install:
+    # - method: pip
+    #   path: .
+    #   extra_requirements:
+    #     - docs
     - method: pip
-      path: .
-      extra_requirements:
-        - docs
+      package: furo
+    - method: pip
+      package: myst-parser

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,8 +15,7 @@ build:
 sphinx:
   configuration: docs/source/conf.py
 
-# To be able to build API documentation, we need to install both docs
-# requirements and package requirements, it seems.
+# We need to install some Python packages to build API docs.
 python:
   install:
     - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,25 @@
+# Configuration for readthedocs.org.
+# See https://docs.readthedocs.io/en/latest/config-file/v2.html
+
+version: 2
+
+# readthedocs.org uses Python 3.7 by default; mflib has to use Python
+# 3.9 or greater.  This incantation seems to work.
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
+# Tell RTD location of our Sphinx configuration.  Seems to work
+# without this too, although default is docs/conf.py.
+sphinx:
+  configuration: docs/source/conf.py
+
+# To be able to build API documentation, we need to install both docs
+# requirements and package requirements, it seems.
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Install the extra packages required to build API docs: (sphinx, furo
 theme, and myst-parser for parsing markdown files):
 
 ```console
-$ pip install -r docs/requirements.txt
+pip install -r docs/requirements.txt
 ```
 
 Build the documentation by running the following command from the root directory of the repo.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,14 @@ pip install --user .
 This package is documented using sphinx. The `source` directories are already created and populated with reStructuredText ( .rst ) files. The `build` directories are deleted and/or are not included in the repository,
 
 #### Build HTML Documents
-The sphinx theme furo is used. This may need to be installed using  
-`pip install furo`   
-To parse the markdown files (README.md) sphinx needs myst-parser.   
-`pip install myst-parser`   
+
+Install the extra packages required to build API docs: (sphinx, furo
+theme, and myst-parser for parsing markdown files):
+
+```console
+$ pip install -r docs/requirements.txt
+```
+
 Build the documentation by running the following command from the root directory of the repo.
 `sphinx-build -b html docs/source/ docs/build/html`  
 The completed documentation may be accessed by clicking on `/docs/build/html/index.html`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This package is documented using sphinx. The `source` directories are already cr
 Install the extra packages required to build API docs: (sphinx, furo
 theme, and myst-parser for parsing markdown files):
 
-```console
+```
 pip install -r docs/requirements.txt
 ```
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx
+furo
+myst-parser

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,4 @@ setup(
     python_requires=">=3.9",
     install_requires=requirements,
     setup_requires=requirements,
-    extras_require={
-        "docs": ["sphinx", "furo", "myst-parser"],
-    },
 )

--- a/setup.py
+++ b/setup.py
@@ -49,4 +49,7 @@ setup(
     python_requires=">=3.9",
     install_requires=requirements,
     setup_requires=requirements,
+    extras_require={
+        "docs": ["sphinx", "furo", "myst-parser"],
+    },
 )


### PR DESCRIPTION
Issue is #5.

Normally the defaults of readthedocs.org's doc builders (Python 3.7 and Sphinx) should work, but in order to be able to build mflib API docs, we need a little more than that: we need Python 3.9, and some extra packages (furo, myst-parser).  This configuration should take care of that.